### PR TITLE
fix(cli): import-directory is missing the application context

### DIFF
--- a/superset/cli/importexport.py
+++ b/superset/cli/importexport.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 @click.command()
+@with_appcontext
 @click.argument("directory")
 @click.option(
     "--overwrite",


### PR DESCRIPTION
See https://github.com/apache/superset/issues/21254

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
